### PR TITLE
Enhancements and bug fixes based on first tests at the beamline

### DIFF
--- a/pco_rclient/client/pco_client.py
+++ b/pco_rclient/client/pco_client.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Client to control the gigafrost writer
 """
 
@@ -13,8 +14,11 @@ import inspect
 
 class NoTraceBackWithLineNumber(Exception):
     def __init__(self, msg):
-        if type(msg).__name__ == "ConnectionError" or  type(msg).__name__ == "ReadTimeout":
-            print("\n ConnectionError/ReadTimeout: it seems that the server is not running (check xbl-daq-32 pco writer service (pco_writer_1), ports, etc).\n")
+        if (type(msg).__name__ == "ConnectionError" or
+            type(msg).__name__ == "ReadTimeout"):
+            print("\n ConnectionError/ReadTimeout: it seems that the server "
+                  "is not running (check xbl-daq-32 pco writer service "
+                  "(pco_writer_1), ports, etc).\n")
         try:
             ln = sys.exc_info()[-1].tb_lineno
         except AttributeError:
@@ -26,7 +30,7 @@ class PcoError(NoTraceBackWithLineNumber):
     pass
 
 class PcoWarning(NoTraceBackWithLineNumber):
-    pass      
+    pass
 
 # TODO implementation of proper validation tests
 def is_valid_connection_addres(connection_address):
@@ -77,146 +81,169 @@ class PcoWriter(object):
     """Proxy Class to control the PCO writer
     """
     def __str__(self):
-        return "Proxy Class to control the PCO writer. It communicates with the flask server running on xbl-daq-32 and the writer process service (pco_writer_1)."
+        return("Proxy Class to control the PCO writer. It communicates with "
+               "the flask server running on xbl-daq-32 and the writer process "
+               "service (pco_writer_1).")
 
-    def __init__(self, output_file='', dataset_name='data', connection_address='tcp://129.129.99.104:8080', n_frames=0,
-                user_id=503, max_frames_per_file=20000):
+    def __init__(self, output_file='', dataset_name='data', n_frames=0,
+                 user_id=503, max_frames_per_file=20000,
+                 connection_address='tcp://129.129.99.104:8080',
+                 writer_server='xbl-daq-32'):
         self.connection_address = connection_address
-        self.flask_api_address = "http://%s:%s" % ('xbl-daq-32', 9901)
-        self.writer_api_address = "http://%s:%s" % ('xbl-daq-32', 9555)
-        is_writer_running = self.is_running()
-        if not is_writer_running:
+        self.flask_api_address = "http://%s:%s" % (writer_server, 9901)
+        self.writer_api_address = "http://%s:%s" % (writer_server, 9555)
+        if not self.is_running():
             self.output_file = output_file
             self.dataset_name = dataset_name
-            if isinstance(n_frames, int):
-                self.n_frames = n_frames
-            if isinstance(max_frames_per_file, int):
-                self.max_frames_per_file = max_frames_per_file
-            if isinstance(user_id, int):
-                self.user_id = user_id
+            self.n_frames = int(n_frames)
+            self.max_frames_per_file = int(max_frames_per_file)
+            self.user_id = int(user_id)
         else:
-            print("\n Writer configuration can not be updated while PCO writer is running. Please, stop() the writer to change configuration.\n")
-        
-        self.configuration = self.validate_internal_configuration()
+            raise RuntimeError("\n Writer configuration can not be updated "
+                "while the PCO writer is running. Please, stop() the writer "
+                " first and then change the configuration.\n")
 
-    def set_configuration(self, output_file=None, dataset_name=None, n_frames=0,
-                user_id=503, max_frames_per_file=20000, verbose=False):
-        is_writer_running = self.is_running()
-        if not is_writer_running:
+        self.configured = self.validate_internal_configuration()
+
+    def set_configuration(self, output_file=None, dataset_name=None,
+            n_frames=None, user_id=None, max_frames_per_file=None,
+            verbose=False):
+        if not self.is_running():
             if output_file is not None:
                 self.output_file = output_file
             if dataset_name is not None:
                 self.dataset_name = dataset_name
-            if isinstance(n_frames, int):
-                self.n_frames = n_frames
-            if isinstance(user_id, int):
-                self.user_id = user_id
-            if isinstance(max_frames_per_file, int):
-                self.max_frames_per_file = max_frames_per_file
-            self.configuration = False
-            self.configuration = self.validate_internal_configuration()
+            if n_frames is not None:
+                self.n_frames = int(n_frames)
+            if user_id is not None:
+                self.user_id = int(user_id)
+            if max_frames_per_file is not None:
+                self.max_frames_per_file = int(max_frames_per_file)
+            self.configured = False
+            self.configured = self.validate_internal_configuration()
             if verbose:
                 print("\nUpdated PCO writer configuration:\n")
                 pprint.pprint(self.get_configuration())
                 print("\n")
         else:
             if verbose:
-                print("\n Writer configuration can not be updated while PCO writer is running. Please, stop() the writer to change configuration.\n")
-
-
+                print("\n Writer configuration can not be updated while PCO "
+                      "writer is running. Please, stop() the writer to change "
+                      "configuration.\n")
 
     def get_configuration(self, verbose=False):
-        configuration_dict = {
-            "connection_address" : self.connection_address,
-            "output_file":self.output_file,
-            "n_frames" : str(self.n_frames),
-            "user_id" : str(self.user_id),
-            "dataset_name" : self.dataset_name,
-            "max_frames_per_file" : str(self.max_frames_per_file)
-        }
-        if verbose:
-            print("\nPCO writer configuration:\n")
-            pprint.pprint(self.get_configuration())
-            print("\n")
-        return(configuration_dict)
+        if self.configured:
+            configuration_dict = {
+                "connection_address" : self.connection_address,
+                "output_file":self.output_file,
+                "n_frames" : str(self.n_frames),
+                "user_id" : str(self.user_id),
+                "dataset_name" : self.dataset_name,
+                "max_frames_per_file" : str(self.max_frames_per_file)
+            }
+            if verbose:
+                print("\nPCO writer configuration:\n")
+                pprint.pprint(self.get_configuration())
+                print("\n")
+            return(configuration_dict)
+        else:
+            return None
 
     def start_writer(self, verbose=False):
         """start a new writer process
         """
 
-        if not self.configuration:
-            raise RuntimeError('please call set_configuration() before you start_writer()')
-        
+        if not self.configured:
+            raise RuntimeError("please configure the writer by calling the "
+                "set_configuration() command before you start_writer()")
+
         # check if writer is running before starting it
-        is_writer_running = self.is_running()
-        if not is_writer_running:
+        if not self.is_running():
             request_url = self.flask_api_address + ROUTES["start_pco"]
             try:
-                response = requests.post(request_url, data=json.dumps(self.get_configuration())).json()
+                response = requests.post(request_url,
+                    data=json.dumps(self.get_configuration())).json()
                 if validate_response(response):
                     if verbose:
-                        time.sleep(1)#giving some time before returning to the cli
-                        print("\nPCO writer trigger start successfully submitted to the server.\n")
+                        #giving some time before returning to the cli - why?
+                        time.sleep(1)
+                        print("\nPCO writer trigger start successfully "
+                              "submitted to the server.\n")
                 else:
-                    print("\nPCO writer trigger start failed. Server response: %s\n" % (response))
+                    print("\nPCO writer trigger start failed. "
+                          "Server response: %s\n" % (response))
             except Exception as e:
                 raise PcoWarning(e)
         else:
-            print("\nWriter is already running, impossible to start_writer() again. Getting the status of the writer... \n")
-            self.get_status(True)
+            print("\nWriter is already running, impossible to start_writer() "
+                  "again. Getting the status of the writer... \n")
+            self.get_status(verbose=True)
 
     def wait_writer(self, verbose=False, wait_time=5):
-        """wait the writer 
+        """Wait for the writer to finish the writing process.
         """
+
+        # TODO: correctly implement the wait_time
+        #       A global timeout is probably not a good idea since it is very
+        #       difficult to predict in a simple way how long the writer will
+        #       be busy to write a given data stream. It's probably better to
+        #       check if the number of written frames keeps chaning (meaning
+        #       the writer is working), and if that is not the case for a given
+        #       maximum duration of inactivity, then the wait process times
+        #       out.
+
         # check if writer is running before killing it
-        is_writer_running = self.is_running()
-        if not is_writer_running:
+        if not self.is_running():
             if verbose:
-                print("\nWriter is not running, nothing to wait_writer(). Please start it using the start_writer() method.\n")
+                print("\nWriter is not running, nothing to wait_writer(). "
+                      "Please start it using the start_writer() method.\n")
             return
         spinner = itertools.cycle(['-', '/', '|', '\\'])
         try:
-            while is_writer_running:
+            while self.is_running():
                 n_written_frames = self.get_written_frames()
-                is_writer_running = self.is_running()
-                for _ in range(50):
+                for _ in range(50):   # ??? Wait_time not used???
                     if verbose:
-                        msg = "Waiting ... Current number of written frames: %s %s (Ctrl-C to stop waiting)" % ((str(n_written_frames)),(next(spinner)))
+                        msg = ("Waiting ... Current number of written frames: "
+                               "%s %s (Ctrl-C to stop waiting)" %
+                               ((str(n_written_frames)),(next(spinner)))
                         sys.stdout.write(msg)
                         sys.stdout.flush()
                         time.sleep(0.1)
                         sys.stdout.write('\r')
                         sys.stdout.flush()
-                        if not is_writer_running:
+                        if not self.is_running():
                             break
         except KeyboardInterrupt:
             pass
         if verbose :
-            if not is_writer_running:
-                print("\nWriter is not running anymore, exiting wait_writer().\n")
+            if not self.is_running():
+                print("\nWriter is not running anymore, exiting "
+                      "wait_writer().\n")
             else:
                 print("\nWriter is still running, exiting wait_writer().\n")
-        
 
     def stop_writer(self, verbose=False):
-        """stop the writer 
+        """Stop the writer
         """
         # check if writer is running before killing it
-        is_writer_running = self.is_running()
-        if is_writer_running:
+        if self.is_running():
             request_url = self.writer_api_address + ROUTES["stop"]
             try:
                 response = requests.get(request_url).json()
                 if validate_response(response):
                     if verbose:
-                        print("\nPCO writer trigger stop successfully submitted to the server.\n")
+                        print("\nPCO writer trigger stop successfully "
+                              "submitted to the server.\n")
                 else:
-                    print("\nPCO writer stop writer failed. Server response: %s\n" % (response))
+                    print("\nPCO writer stop writer failed. Server response: "
+                          "%s\n" % (response))
             except Exception as e:
                 raise PcoError(e)
         else:
             if verbose:
-                print("\nWriter is not running, impossible to stop_writer(). Please start it using the start_writer() method.\n")
+                print("\nWriter is not running, impossible to stop_writer(). "
+                      "Please start it using the start_writer() method.\n")
 
     def get_written_frames(self):
         request_url = self.writer_api_address + ROUTES["statistics"]
@@ -243,9 +270,11 @@ class PcoWriter(object):
                 raise PcoError(e)
         else:
             if verbose:
-                print("\nWriter is not running, impossible to get_statistics(). Please start it using the start_writer() method.\n")
+                print("\nWriter is not running, impossible to "
+                      "get_statistics(). Please start it using the "
+                      "start_writer() method.\n")
 
-    def get_status(self,verbose=False):
+    def get_status(self, verbose=False):
         request_url = self.flask_api_address+ROUTES["status"]
         try:
             response = requests.get(request_url, timeout=3).json()
@@ -261,7 +290,8 @@ class PcoWriter(object):
         request_url = self.flask_api_address+ROUTES["status"]
         try:
             response = requests.get(request_url, timeout=3).json()
-            if response['value'] == 'receiving' or response['value'] == 'writing':
+            if (response['value'] == 'receiving' or
+                response['value'] == 'writing'):
                 return True
             else:
                 return False
@@ -270,8 +300,7 @@ class PcoWriter(object):
 
     def kill_writer(self, verbose=False):
         # check if writer is running before killing it
-        is_writer_running = self.is_running()
-        if is_writer_running:
+        if self.is_running():
             request_url = self.writer_api_address + ROUTES["kill"]
             try:
                 response = requests.get(request_url).json()
@@ -284,14 +313,17 @@ class PcoWriter(object):
                 raise PcoError(e)
         else:
             if verbose:
-                print("\nWriter is not running, impossible to kill(). Please start it using the start_writer() method.\n")
+                print("\nWriter is not running, impossible to kill(). Please "
+                      "start it using the start_writer() method.\n")
 
-    def _clear_configuration(self):
-        self._configuration = False
+    # This does not seem to be used at all???
+    #def _clear_configuration(self):
+    #    self._configuration = False
 
     def validate_internal_configuration(self):
         # if self.get_configuration() is not None:
-        #     raise RuntimeError('already configured, call reset() if you want to reconfigure ')
+        #     raise RuntimeError('already configured, call reset() if you '
+        #                        'want to reconfigure')
         # basic verification if all the parameters are in place
         # if not is_valid_connection_addres(self.connection_address):
         #     raise RuntimeError('Problem with the connection address')
@@ -306,4 +338,3 @@ class PcoWriter(object):
         # if not is_valid_frames_per_file(self.max_frames_per_file):
         #     raise RuntimeError('Problem with the max_frames_per_file')
         return True
-


### PR DESCRIPTION
Fixed issue where the set_configuration() command would overwrite already configured parameters with default values if not all optional arguments were specified in the call; Changed many configuration options to fail explicitly if invalid parameters are given, rather than ignoring the invalid input (which is much harder to debug for the end user); renamed self.configuration to self.configured; some pep8 cleanup and other small cosmetic changes.